### PR TITLE
fix/typo: Fix typo issue on file import

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,10 +1,10 @@
-import sys
 import os
+import sys
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pygip.datasets.datasets import *
 from pygip.protect import *
-from pygip.protect.Defense import Watermark_sage
-
+from pygip.protect.defense import Watermark_sage
 
 # dataset = Cora()
 # dataset = Citeseer()
@@ -135,3 +135,4 @@ def test():
         elif (dataset_name == 3):
             defense = Watermark_sage(PubMed(), 0.25)
             defense.watermark_attack(PubMed(), attack_name, dataset_name)
+test()

--- a/pygip/protect/__init__.py
+++ b/pygip/protect/__init__.py
@@ -1,1 +1,1 @@
-from .gnn_mea import *
+from .attack import *


### PR DESCRIPTION
## PR Description
Firstly, the file `pygip/protect/__init__.py` is importing non existing file which is a typo error. This should be attack.py because the user who had renamed this file has forgotten to rename in all place where it is being used. Secondly, the `test()` is not called which is ambiguous to the new developer as the program runs but without giving any output. 

<img width="1175" alt="Screenshot 2024-12-28 at 12 08 18" src="https://github.com/user-attachments/assets/d1e3cac4-969f-424c-9259-7b2c01cf94e7" />


