### PR TITLE
feat(defense): add Revisiting (BaseDefense)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+*pygip.egg-info
 # PyInstaller
 #  Usually contains a build/ and dist/ folder
 *.manifest

--- a/examples/revisiting_cora.py
+++ b/examples/revisiting_cora.py
@@ -1,0 +1,22 @@
+from datasets import Cora
+from models.defense import Revisiting
+
+
+def main():
+    # Load dataset
+    dataset = Cora()
+
+    # Init defense (tweak params as needed)
+    defense = Revisiting(
+        dataset,
+        attack_node_fraction=0.20,  # fraction of nodes to mix
+        alpha=0.80,                 # neighbor-mixing strength [0,1]
+    )
+
+    print("Initialized Revisiting defense; starting defend()...")
+    results = defense.defend()
+    print("Defense finished. Results:", results)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/defense/Revisiting.py
+++ b/models/defense/Revisiting.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, Iterable, Tuple
+
+import dgl
+import torch
+import torch.nn.functional as F
+from dgl.dataloading import NeighborSampler, NodeCollator
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from models.defense.base import BaseDefense
+from models.nn import GraphSAGE
+
+
+class Revisiting(BaseDefense):
+    """
+    A lightweight defense that 'revisits' node features via neighbor mixing.
+
+    Idea (defense intuition)
+    ------------------------
+    We pick a subset of nodes (size ~ attack_node_fraction * |V|) and *smoothly*
+    mix their features with their 1-hop / 2-hop neighborhoods using a mixing
+    factor `alpha`. This keeps utility (accuracy) largely intact while making
+    local feature structure less extractable for subgraph-based queries.
+
+    API shape follows RandomWM:
+      - lives under models/defense/
+      - inherits BaseDefense
+      - public entrypoint: .defend()
+
+    Parameters
+    ----------
+    dataset : Any
+        A dataset object providing a DGLGraph in `dataset.graph_data` and
+        ndata fields: 'feat', 'label', 'train_mask', 'test_mask'.
+    attack_node_fraction : float, default=0.2
+        Fraction of nodes used as the 'focus set' for our revisiting transform.
+    alpha : float, default=0.8
+        Mixing coefficient in [0,1]. Higher -> stronger neighbor mixing.
+    """
+
+    supported_api_types = {"dgl"}
+
+    def __init__(
+        self,
+        dataset: Any,
+        attack_node_fraction: float = 0.2,
+        alpha: float = 0.8,
+    ) -> None:
+        super().__init__(dataset, attack_node_fraction)
+
+        # knobs
+        self.alpha = float(alpha)
+
+        # cache handles similar to RandomWM for consistency
+        self.dataset = dataset
+        self.graph: dgl.DGLGraph = dataset.graph_data
+
+        self.num_nodes = dataset.num_nodes
+        self.num_features = dataset.num_features
+        self.num_classes = dataset.num_classes
+        self.num_focus_nodes = max(1, int(self.num_nodes * attack_node_fraction))
+
+        self.features: torch.Tensor = self.graph.ndata["feat"]
+        self.labels: torch.Tensor = self.graph.ndata["label"]
+        self.train_mask: torch.Tensor = self.graph.ndata["train_mask"]
+        self.test_mask: torch.Tensor = self.graph.ndata["test_mask"]
+
+        if self.device != "cpu":
+            self.graph = self.graph.to(self.device)
+            self.features = self.features.to(self.device)
+            self.labels = self.labels.to(self.device)
+            self.train_mask = self.train_mask.to(self.device)
+            self.test_mask = self.test_mask.to(self.device)
+
+    # --------------------------------------------------------------------- #
+    # Public entrypoint
+    # --------------------------------------------------------------------- #
+    def defend(self) -> Dict[str, Any]:
+        """
+        1) Train a baseline GraphSAGE on the original graph (utility baseline)
+        2) Apply revisiting feature-mixing on a subset of nodes
+        3) Train a defended GraphSAGE on the transformed features
+        4) Return accuracy metrics and basic metadata
+        """
+        # ---- Baseline (no transform) ------------------------------------- #
+        baseline_acc = self._train_and_eval_graphsage(use_transformed_features=False)
+
+        # ---- Build transformed features (revisiting) --------------------- #
+        feat_defended, picked = self._build_revisiting_features()
+
+        # ---- Train with defended features -------------------------------- #
+        # Temporarily override graph features, then restore
+        orig_feat = self.graph.ndata["feat"]
+        try:
+            self.graph.ndata["feat"] = feat_defended
+            defense_acc = self._train_and_eval_graphsage(use_transformed_features=True)
+        finally:
+            self.graph.ndata["feat"] = orig_feat  # restore
+
+        return {
+            "ok": True,
+            "method": "Revisiting",
+            "alpha": self.alpha,
+            "focus_nodes": int(self.num_focus_nodes),
+            "baseline_test_acc": float(baseline_acc),
+            "defense_test_acc": float(defense_acc),
+            "acc_delta": float(defense_acc - baseline_acc),
+            # returning a small sample of picked nodes for debuggability
+            "sample_picked_nodes": picked[:10].tolist() if isinstance(picked, torch.Tensor) else [],
+        }
+
+    # --------------------------------------------------------------------- #
+    # Core: feature revisiting (neighbor mixing)
+    # --------------------------------------------------------------------- #
+    def _build_revisiting_features(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Returns a new feature tensor where a subset of nodes (and optionally
+        their neighbors) are mixed with neighbor features.
+
+        Mixing rule (simple & stable):
+          - For each picked node u:
+              x[u] <- (1 - alpha) * x[u] + alpha * mean(x[N(u)])
+          - For each 1-hop neighbor v in N(u) we apply a *lighter* mix
+              x[v] <- (1 - 0.5*alpha) * x[v] + (0.5*alpha) * mean(x[N(v)])
+
+        This keeps the transform localized and smooth.
+        """
+        g = self.graph
+        x = self.features.clone()
+
+        # pick focus nodes
+        picked = torch.randperm(self.num_nodes, device=self.device)[: self.num_focus_nodes]
+
+        # precompute neighbor lists (on CPU tensors if needed)
+        # we'll use undirected neighborhood by combining predecessors/successors
+        def neighbors(nodes: Iterable[int]) -> torch.Tensor:
+            cols = []
+            for n in nodes:
+                # concatenate in- and out-neighbors to emulate undirected
+                nb = torch.unique(
+                    torch.cat([g.successors(int(n)), g.predecessors(int(n))], dim=0)
+                )
+                if nb.numel() > 0:
+                    cols.append(nb)
+            if not cols:
+                return torch.empty(0, dtype=torch.long, device=self.device)
+            return torch.unique(torch.cat(cols))
+
+        # 1) mix picked nodes with mean of their neighbors
+        for u in picked.tolist():
+            nb = neighbors([u])
+            if nb.numel() == 0:
+                continue
+            mean_nb = self.features[nb].mean(dim=0)
+            x[u] = (1.0 - self.alpha) * self.features[u] + self.alpha * mean_nb
+
+        # 2) lightly mix 1-hop neighbors as well (half strength)
+        one_hop = neighbors(picked.tolist())
+        for v in one_hop.tolist():
+            nb = neighbors([v])
+            if nb.numel() == 0:
+                continue
+            mean_nb = self.features[nb].mean(dim=0)
+            x[v] = (1.0 - 0.5 * self.alpha) * self.features[v] + (0.5 * self.alpha) * mean_nb
+
+        return x, picked
+
+    # --------------------------------------------------------------------- #
+    # Training/Eval (same style as RandomWM)
+    # --------------------------------------------------------------------- #
+    def _train_and_eval_graphsage(self, use_transformed_features: bool) -> float:
+        """
+        Train a GraphSAGE for a few epochs and return test accuracy.
+        Uses NeighborSampler + NodeCollator (same pattern as RandomWM).
+        """
+        model = GraphSAGE(
+            in_channels=self.num_features,
+            hidden_channels=128,
+            out_channels=self.num_classes,
+        ).to(self.device)
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=5e-4)
+        sampler = NeighborSampler([5, 5])
+
+        train_nids = self.train_mask.nonzero(as_tuple=True)[0].to(self.device)
+        test_nids = self.test_mask.nonzero(as_tuple=True)[0].to(self.device)
+
+        train_collator = NodeCollator(self.graph, train_nids, sampler)
+        test_collator = NodeCollator(self.graph, test_nids, sampler)
+
+        train_loader = DataLoader(
+            train_collator.dataset,
+            batch_size=32,
+            shuffle=True,
+            collate_fn=train_collator.collate,
+            drop_last=False,
+        )
+        test_loader = DataLoader(
+            test_collator.dataset,
+            batch_size=32,
+            shuffle=False,
+            collate_fn=test_collator.collate,
+            drop_last=False,
+        )
+
+        best_acc = 0.0
+        for _ in tqdm(range(1, 51), desc=("GraphSAGE (defended)" if use_transformed_features else "GraphSAGE (baseline)")):
+            # ---- Train
+            model.train()
+            for _, _, blocks in train_loader:
+                blocks = [b.to(self.device) for b in blocks]
+                feats = blocks[0].srcdata["feat"]
+                labels = blocks[-1].dstdata["label"]
+
+                optimizer.zero_grad()
+                logits = model(blocks, feats)
+                loss = F.cross_entropy(logits, labels)
+                loss.backward()
+                optimizer.step()
+
+            # ---- Eval
+            model.eval()
+            correct = 0
+            total = 0
+            with torch.no_grad():
+                for _, _, blocks in test_loader:
+                    blocks = [b.to(self.device) for b in blocks]
+                    feats = blocks[0].srcdata["feat"]
+                    labels = blocks[-1].dstdata["label"]
+                    logits = model(blocks, feats)
+                    pred = logits.argmax(dim=1)
+                    correct += (pred == labels).sum().item()
+                    total += labels.numel()
+
+            acc = correct / max(1, total)
+            best_acc = max(best_acc, acc)
+
+        return best_acc

--- a/models/defense/__init__.py
+++ b/models/defense/__init__.py
@@ -1,5 +1,5 @@
 from .RandomWM import RandomWM
-
+from .Revisiting import Revisiting 
 __all__ = [
-    'RandomWM',
+    'RandomWM','Revisiting'
 ]


### PR DESCRIPTION

## 📋 Summary

**feat(defense): add `Revisiting` defense (BaseDefense) + runnable example**

- Adds a new defense class **`Revisiting`** at `models/defense/Revisiting.py`.
- Conforms to the project’s defense API:
  - Lives under `models/defense/`
  - Inherits **`BaseDefense`**
  - Public entrypoint: **`.defend()`**
  - `supported_api_types = {"dgl"}`
- Exports the class in `models/defense/__init__.py`.
- Adds **`examples/revisiting_cora.py`** to demonstrate usage.
- **No changes to `models/attack/*`** (scope kept defense-only per review feedback).

**Method (high-level):**  
Localized **neighbor-mixing** on a subset of nodes (≈ `attack_node_fraction * |V|`):
- For a picked node `u`: `x[u] ← (1 − α)·x[u] + α·mean(x[N(u)])`
- For 1-hop neighbors `v`: lighter mix `0.5·α`

`.defend()` trains GraphSAGE on original features (baseline) and on transformed features (defended) and returns both test accuracies plus metadata.

**How to run**
```bash
python -m examples.revisiting_cora
# or
python examples/revisiting_cora.py
```
### Return value from `.defend()`

```python
{
    "ok": True,
    "method": "Revisiting",
    "alpha": <float>,
    "focus_nodes": <int>,
    "baseline_test_acc": <float>,
    "defense_test_acc": <float>,
    "acc_delta": <float>,
    "sample_picked_nodes": <list[int]>,
}
```

## 🧪 Related Issues

- Addresses prior review feedback (Bolin) that this implementation is a **defense**, should live under `models/defense/`, and should use a `.defend()` API by inheriting `BaseDefense`.
- _(Optional)_ Link issues here: `Closes #<id>`, `Fixes #<id>`, etc.

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes and verified that they work (Cora example runs end-to-end)
- [x] I have added necessary documentation (docstrings + example)
- [x] I have linked related issues above (if any)
- [x] The PR is made from a feature branch (e.g., `feat/revisiting-defense`), not `main`


## 🧠 Additional Context (Optional)

**Files added/updated**
- `models/defense/Revisiting.py` — new defense (inherits `BaseDefense`)
- `models/defense/__init__.py` — export `Revisiting`
- `examples/revisiting_cora.py` — runnable example

**Example output on Cora (`alpha = 0.8`, `attack_node_fraction = 0.2`)**
~~~yaml
baseline_test_acc: 0.807
defense_test_acc : 0.799
acc_delta        : -0.008
focus_nodes      : 541 / 2708
sample_picked_nodes: [1352, 1472, 2024, 146, 820, 1397, 497, 2649, 1969, 1573]
~~~

_Small utility drop is expected with feature mixing; tuning `alpha` (e.g., 0.4–0.6) can adjust the trade-off._

**Design notes**
- Mirrors `RandomWM` pattern (DGL + NeighborSampler/NodeCollator + GraphSAGE).
- Feature swap during training is wrapped in `try/finally` to restore original features.
- Scope kept **defense-only**; any new attacks will be proposed in a separate PR.
